### PR TITLE
Add generate.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
 # spacemacs theme gallery
+
 http://themegallery.robdor.com/
 
 A theme gallery for themes bundled with Spacemacs
 
+## Generate your theme-gallery
+
+The following command will execute `emacs` and open a buffer with the contents of `sample.exs`
+and generate a `index.html` file with your currently installed themes.
+
+```shell
+./generate.sh sample.exs
+```
+
+## From inside emacs
+
 To generate the gallery open a file that you would like to use as the theme sample code and invoke: (generate-theme-gallery)
 
 A new buffer will be created with the contents of the theme gallery's html.
+
+You need to have the `htmlize` package already installed for this to work.

--- a/generate.el
+++ b/generate.el
@@ -51,11 +51,15 @@
 
 (defun generate-theme-div (tpl theme)
   "Generate the div for a single theme"
-  (helm-themes--load-theme theme)
-  (let* ((buffer-faces (htmlize-faces-in-buffer))
-         (face-map (htmlize-make-face-map (adjoin 'default buffer-faces)))
-         (style (mapconcat #'identity (htmlize-css-specs (gethash 'default face-map)) " ")))
-    (s-format tpl 'elt (list theme style (mark-and-htmlize-buffer)))))
+  (or
+   (condition-case nil
+       (progn (helm-themes--load-theme theme) nil)
+       (error 
+        (s-format tpl 'elt (list theme "" "error: could not load theme"))))
+   (let* ((buffer-faces (htmlize-faces-in-buffer))
+          (face-map (htmlize-make-face-map (adjoin 'default buffer-faces)))
+          (style (mapconcat #'identity (htmlize-css-specs (gethash 'default face-map)) " ")))
+     (s-format tpl 'elt (list theme style (mark-and-htmlize-buffer))))))
 
 (defun generate-and-join-all-theme-divs (tpl themes)
   "Generate the divs containing the themed content that is embedded inside of the index.html layout"

--- a/generate.sh
+++ b/generate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+BASE=$(dirname $BASH_SOURCE)
+SAMPLE=${1:-$BASE/sample.exs}
+TMPEL=$(mktemp)
+TARGET=$BASE/index.html
+cat > $TMPEL <<EOF
+(spacemacs/toggle-debug-on-error-on)
+(unless (locate-library "htmlize") (package-install 'htmlize))
+(add-to-load-path "$BASE")
+(cd "$BASE")
+(load "generate.el")
+(find-file "$SAMPLE")
+(generate-theme-gallery)
+(with-current-buffer (get-buffer "theme-gallery")
+  (write-file "$TARGET"))
+(browse-url "file://$TARGET")
+(kill-emacs)
+EOF
+emacs --load $TMPEL && \
+    echo "Gallery generated at $TARGET"


### PR DESCRIPTION
Add a simple shell script so that you can execute just

```shell
./generate.sh sample.ex
```

And let emacs generate the theme gallery for you.
This way users (like me) can generate the html for the themes currently installed on their spacemacs conf.

Make sure problematic themes don’t interrupt the gallery generation.